### PR TITLE
Remove dependency to lwt_ppx

### DIFF
--- a/ocsipersist-lib.opam
+++ b/ocsipersist-lib.opam
@@ -15,5 +15,4 @@ build:   [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
   "dune" {>= "2.9"}
   "lwt" {>= "4.2.0"}
-  "lwt_ppx" {>= "2.0.0"}
 ]

--- a/src/dune
+++ b/src/dune
@@ -3,9 +3,7 @@
  (public_name ocsipersist-lib)
  (modules ocsipersist_lib)
  (wrapped false)
- (libraries lwt)
- (preprocess
-  (pps lwt_ppx)))
+ (libraries lwt))
 
 (library
  (name ocsipersist)


### PR DESCRIPTION
This PR proposes to remove the dependency to `lwt_ppx`

This is the first step toward moving from lwt to direct style.
