### PR TITLE
Migrate from Lwt_log to Logs

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@
  (depends
   (ocsipersist (= :version))
   (lwt (>= 4.2.0))
-  lwt_log
+  logs
   dbm))
 
 (package
@@ -54,7 +54,7 @@
   (ocaml (>= 4.08))
   (ocsipersist (= :version))
   (lwt (>= 4.2.0))
-  lwt_log
+  logs
   pgocaml))
 
 (package
@@ -72,7 +72,7 @@
  (description "This library provides a SQLite backend for the unified key/value storage frontend as defined in the ocsipersist package.")
  (depends
   (lwt (>= 4.2.0))
-  lwt_log
+  logs
   ocsipersist
   sqlite3))
 

--- a/ocsipersist-dbm.opam
+++ b/ocsipersist-dbm.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.8"}
   "ocsipersist" {= version}
   "lwt" {>= "4.2.0"}
-  "lwt_log"
+  "logs"
   "dbm"
   "odoc" {with-doc}
 ]

--- a/ocsipersist-pgsql.opam
+++ b/ocsipersist-pgsql.opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "ocsipersist" {= version}
   "lwt" {>= "4.2.0"}
-  "lwt_log"
+  "logs"
   "pgocaml"
   "odoc" {with-doc}
 ]

--- a/ocsipersist-sqlite.opam
+++ b/ocsipersist-sqlite.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
 depends: [
   "dune" {>= "2.8"}
   "lwt" {>= "4.2.0"}
-  "lwt_log"
+  "logs"
   "ocsipersist"
   "sqlite3"
   "odoc" {with-doc}

--- a/src/dbm/dune
+++ b/src/dbm/dune
@@ -18,7 +18,7 @@
   ocsipersist_settings)
  (libraries
   dbm
-  lwt_log
+  logs
   ocsipersist_dbmtypes
   ocsipersist_lib
   ocsipersist_dbm_settings))

--- a/src/pgsql/dune
+++ b/src/pgsql/dune
@@ -3,7 +3,7 @@
  (public_name ocsipersist-pgsql)
  (implements ocsipersist)
  (modules :standard \ ocsipersist_config ocsipersist_settings)
- (libraries pgocaml lwt_log ocsipersist_lib ocsipersist_pgsql_settings))
+ (libraries pgocaml lwt.unix logs ocsipersist_lib ocsipersist_pgsql_settings))
 
 ; Configuration functions (part of ocsipersist-pgsql package):
 

--- a/src/pgsql/ocsipersist.ml
+++ b/src/pgsql/ocsipersist.ml
@@ -2,7 +2,7 @@
 
 module type TABLE = Ocsipersist_lib.Sigs.TABLE
 
-let section = Lwt_log.Section.make "ocsigen:ocsipersist:pgsql"
+let section = Logs.Src.create "ocsigen:ocsipersist:pgsql"
 
 module Lwt_thread = struct
   include Lwt
@@ -55,10 +55,11 @@ let use_pool f =
     (fun () -> f db)
     (function
        | PGOCaml.Error msg as e ->
-           Lwt_log.ign_error_f ~section "postgresql protocol error: %s" msg;
+           Logs.err ~src:section (fun fmt ->
+             fmt "postgresql protocol error: %s" msg);
            PGOCaml.close db >>= fun () -> Lwt.fail e
        | Lwt.Canceled as e ->
-           Lwt_log.ign_error ~section "thread canceled";
+           Logs.err ~src:section (fun fmt -> fmt "thread canceled");
            PGOCaml.close db >>= fun () -> Lwt.fail e
        | e -> Lwt.fail e)
 

--- a/src/pgsql/ocsipersist_config.ml
+++ b/src/pgsql/ocsipersist_config.ml
@@ -1,5 +1,7 @@
-let section = Lwt_log.Section.make "ocsigen:ocsipersist:pgsql:config"
-let _ = Lwt_log.ign_info ~section "Init for Ocsigen Server config file"
+let section = Logs.Src.create "ocsigen:ocsipersist:pgsql:config"
+
+let _ =
+  Logs.info ~src:section (fun fmt -> fmt "Init for Ocsigen Server config file")
 
 let parse_global_config = function
   | [] -> ()

--- a/src/sqlite/dune
+++ b/src/sqlite/dune
@@ -3,7 +3,12 @@
  (public_name ocsipersist-sqlite)
  (implements ocsipersist)
  (modules ocsipersist)
- (libraries sqlite3 lwt_log ocsipersist_lib ocsipersist_sqlite_settings))
+ (libraries
+  sqlite3
+  lwt.unix
+  logs
+  ocsipersist_lib
+  ocsipersist_sqlite_settings))
 
 ; Configuration functions (part of ocsipersist-sqlite package):
 

--- a/src/sqlite/ocsipersist.ml
+++ b/src/sqlite/ocsipersist.ml
@@ -1,6 +1,6 @@
 module type TABLE = Ocsipersist_lib.Sigs.TABLE
 
-let section = Lwt_log.Section.make "ocsigen:ocsipersist:sqlite"
+let section = Logs.Src.create "ocsigen:ocsipersist:sqlite"
 
 open Lwt.Infix
 open Sqlite3
@@ -24,7 +24,7 @@ module Aux = struct
 
   let close_safely db =
     if not (db_close db)
-    then Lwt_log.ign_error ~section "Couldn't close database"
+    then Logs.err ~src:section (fun fmt -> fmt "Couldn't close database")
 
   let m = Mutex.create ()
 


### PR DESCRIPTION
This done automatically thanks to https://github.com/Julow/lwt-to-direct-style The `lwt.unix` dependency is added because it previously was a transitive dependency through lwt_log.