### PR TITLE
Fix Functorial.fold on the PostgreSQL backend (issue #19)

### DIFF
--- a/src/pgsql/ocsipersist.ml
+++ b/src/pgsql/ocsipersist.ml
@@ -327,7 +327,9 @@ module Functorial = struct
         res := res';
         Lwt.return_unit
       in
-      iter ?count ?gt ?geq ?lt ?leq g >> Lwt.return !res
+      (* Read [res] only once [iter] has completed: [>>] would evaluate
+         [Lwt.return !res] eagerly and capture the initial accumulator. *)
+      iter ?count ?gt ?geq ?lt ?leq g >>= fun () -> Lwt.return !res
 
     let iter_block ?count:_ ?gt:_ ?geq:_ ?lt:_ ?leq:_ _ =
       failwith "Ocsipersist.iter_block: not implemented"

--- a/test/pgsql/pgsql.t/run.t
+++ b/test/pgsql/pgsql.t/run.t
@@ -12,6 +12,9 @@ Run the test:
 
   $ dune exec -- ./test.exe
   length after 3 adds: 3
+  fold count: 3
+  fold concat: a=1;b=2;c=3;
+  iter keys: a,b,c
   length after remove: 2
 
 Tear down:

--- a/test/pgsql/pgsql.t/test.ml
+++ b/test/pgsql/pgsql.t/test.ml
@@ -28,6 +28,20 @@ let main () =
   let* () = T.add "c" "3" in
   let* n = T.length () in
   Printf.printf "length after 3 adds: %d\n%!" n;
+  (* Regression test for issue #19: fold/iter must see the rows. *)
+  let* count = T.fold (fun _ _ acc -> Lwt.return (acc + 1)) 0 in
+  Printf.printf "fold count: %d\n%!" count;
+  let* concat =
+    T.fold (fun k v acc -> Lwt.return (acc ^ k ^ "=" ^ v ^ ";")) ""
+  in
+  Printf.printf "fold concat: %s\n%!" concat;
+  let keys = ref [] in
+  let* () =
+    T.iter (fun k _ ->
+      keys := k :: !keys;
+      Lwt.return_unit)
+  in
+  Printf.printf "iter keys: %s\n%!" (String.concat "," (List.rev !keys));
   let* () = T.remove "b" in
   let* n = T.length () in
   Printf.printf "length after remove: %d\n%!" n;


### PR DESCRIPTION
Fixes #19.

## Problem

On the PostgreSQL backend, `Ocsipersist.Functorial`'s `fold` (and therefore
`Polymorphic.fold`) silently returned the **initial accumulator** for a table
that contained rows. `add`, `find`, `length` and `iter` all worked.

## Root cause

Contrary to the issue's initial guess, the SQL query and `LIMIT` parameter are
fine: the `iter_rec` `SELECT` returns all rows and `iter` enumerates them
correctly. The bug was in `fold`:

```ocaml
iter ... g >> Lwt.return !res
```

with `let ( >> ) f g = f >>= fun _ -> g`. Because `>>` is an ordinary function,
its second argument `Lwt.return !res` was evaluated **eagerly**, capturing
`!res` at its initial value *before* `iter` ran. The callbacks updated `res`,
but the returned thread already held the starting accumulator.

## Fix

Defer the read until `iter` completes:

```ocaml
iter ... g >>= fun () -> Lwt.return !res
```

## Test

Adds a regression test in `test/pgsql/pgsql.t` covering `fold` (count and
concatenation) and `iter`. It fails against the buggy backend (`fold count: 0`)
and passes with the fix; `iter` stays correct in both cases, confirming the bug
was confined to `fold`.