### PR TITLE
doc: odoc/wodoc migration — manual + API (dev / modernize)

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,41 @@
+# Build the documentation with odoc, theme it with the Ocsigen chrome (wodoc),
+# and publish it on the project's gh-pages branch (https://ocsigen.org/ocsipersist/).
+# See doc/README.md. CI deploys ONLY dev/ from master; stable versions are frozen
+# at release time (`wodoc release`). No client/server split -> plain dune @doc.
+name: Documentation
+on:
+  push:
+    branches: [master]
+  workflow_dispatch: {}
+jobs:
+  build-deploy:
+    if: github.repository == 'ocsigen/ocsipersist'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "5.4.0"
+      - name: Install dependencies
+        run: |
+          opam install . --deps-only --with-doc
+          opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
+          opam install wodoc odoc
+      - name: Build documentation (dev)
+        run: >-
+          opam exec -- wodoc build --config doc/wodoc
+          --menu https://ocsigen.org/doc/menu.html
+          --out "$PWD/_doc-site/dev" --label dev
+      - name: Deploy to gh-pages (replace only dev/, keep the rest)
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: _doc-site/dev
+          target-folder: dev
+          clean: true

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -6,10 +6,15 @@ name: Documentation
 on:
   push:
     branches: [master]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Publish a stable version: freeze the dev docs now on gh-pages as /<version>/ and repoint `latest` (e.g. 1.2.3). Leave empty to just rebuild dev."
+        required: false
+        default: ""
 jobs:
   build-deploy:
-    if: github.repository == 'ocsigen/ocsipersist'
+    if: github.repository == 'ocsigen/ocsipersist' && (github.event_name != 'workflow_dispatch' || github.event.inputs.version == '')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -39,3 +44,46 @@ jobs:
           folder: _doc-site/dev
           target-folder: dev
           clean: true
+
+  release:
+    # Manual run with a version: freeze the dev docs currently on gh-pages as the
+    # stable /<version>/ and repoint `latest` at it (refreshing versions.json).
+    # No rebuild -- the docs of a release are exactly the dev docs at that point.
+    if: github.repository == 'ocsigen/ocsipersist' && github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "5.4.0"
+
+      - name: Install wodoc
+        run: |
+          opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
+          opam install wodoc
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: site
+          fetch-depth: 0
+
+      - name: Freeze dev as the stable version and repoint latest
+        # wodoc release: cp -a site/dev site/<version>, ln -sfn <version> latest,
+        # write the root index.html redirect if missing, refresh versions.json.
+        run: >-
+          opam exec -- wodoc release --site site --from dev
+          --version "${{ github.event.inputs.version }}"
+
+      - name: Commit and push gh-pages
+        run: |
+          cd site
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet \
+            || git commit -m "Release doc ${{ github.event.inputs.version }} (freeze dev, repoint latest)"
+          git push

--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,2 @@
+(documentation
+ (package ocsipersist))

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,42 @@
+{0 Ocsipersist}
+
+Ocsipersist is a collection of libraries defining a unified frontend for a
+number of key/value storage implementations. It is used pervasively in
+Ocsigen/Eliom to handle sessions and persistent references, but can be used as
+a standalone library or as an extension for Ocsigen Server.
+
+Three backends currently exist:
+
+- {{:../ocsipersist-sqlite/index.html}SQLite}
+- {{:../ocsipersist-dbm/index.html}DBM}
+- {{:../ocsipersist-pgsql/index.html}PostgreSQL}
+
+You choose a backend by installing the corresponding package
+([ocsipersist-sqlite], [ocsipersist-dbm] or [ocsipersist-pgsql]); the unified
+frontend is the same in every case.
+
+{1 API reference}
+
+The storage frontend is documented in module {!Ocsipersist}. It defines several
+interfaces:
+
+- [Ref] — the simplest to use: persistent references;
+- [Store] — a lower-level interface for persistent values;
+- [Polymorphic] — a polymorphic table (using [Marshal]);
+- [Functorial] — a type-safe table built from a value description.
+
+See {!Ocsipersist} for the full frontend, and {!Ocsipersist_lib} for the
+backend-independent signatures and functors shared by every backend.
+
+{1 Backends and configuration}
+
+Each backend ships an [Ocsipersist_settings] library to configure storage from
+OCaml, and an optional [ocsipersist-*-config] package to configure it from
+Ocsigen Server's configuration file:
+
+- SQLite: {{:../ocsipersist-sqlite/index.html}usage} ·
+  {{:../ocsipersist-sqlite-config/Ocsipersist_config/index.html}server config}
+- DBM: {{:../ocsipersist-dbm/index.html}usage} ·
+  {{:../ocsipersist-dbm-config/Ocsipersist_config/index.html}server config}
+- PostgreSQL: {{:../ocsipersist-pgsql/index.html}usage} ·
+  {{:../ocsipersist-pgsql-config/Ocsipersist_config/index.html}server config}

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -1,0 +1,28 @@
+;; Declarative wodoc config for the Ocsipersist documentation.
+;; Replaces this project's build.sh AND its hand-written nav (nav.html/leftnav.html):
+;;   wodoc build --config doc/wodoc --src <odoc _html> --out <dir>/<label> \
+;;               --label <v> --menu <shared menu.html> [--latest]
+(project ocsipersist)
+(title Ocsipersist)
+(pub /ocsipersist)
+(profile release)                       ; dune build @doc --profile release
+(landing ocsipersist/index.html)
+;; no (highlight …): Ocsipersist has no ppx, so wodoc's default starter is enough.
+(packages ocsipersist ocsipersist-lib ocsipersist-dbm ocsipersist-sqlite
+          ocsipersist-pgsql ocsipersist-dbm-config ocsipersist-sqlite-config
+          ocsipersist-pgsql-config)
+(nav
+  (section "Ocsipersist"
+    (link "Overview"                 ocsipersist/index.html                            ocsipersist)
+    (link "Ocsipersist (frontend)"   ocsipersist/Ocsipersist/index.html                ocsipersist)
+    (link "Ocsipersist_lib (signatures)" ocsipersist-lib/Ocsipersist_lib/index.html    ocsipersist-lib))
+  (section "Backends"
+    (link "SQLite"     ocsipersist-sqlite/index.html  ocsipersist-sqlite)
+    (link "DBM"        ocsipersist-dbm/index.html     ocsipersist-dbm)
+    (link "PostgreSQL" ocsipersist-pgsql/index.html   ocsipersist-pgsql))
+  (section "Server config"
+    (link "SQLite config"     ocsipersist-sqlite-config/Ocsipersist_config/index.html ocsipersist-sqlite-config)
+    (link "DBM config"        ocsipersist-dbm-config/Ocsipersist_config/index.html    ocsipersist-dbm-config)
+    (link "PostgreSQL config" ocsipersist-pgsql-config/Ocsipersist_config/index.html  ocsipersist-pgsql-config))
+  (api-section "API"
+    (link "Ppx" Ppx/index.html Ppx)))

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -23,6 +23,4 @@
   (section "Server config"
     (link "SQLite config"     ocsipersist-sqlite-config/Ocsipersist_config/index.html ocsipersist-sqlite-config)
     (link "DBM config"        ocsipersist-dbm-config/Ocsipersist_config/index.html    ocsipersist-dbm-config)
-    (link "PostgreSQL config" ocsipersist-pgsql-config/Ocsipersist_config/index.html  ocsipersist-pgsql-config))
-  (api-section "API"
-    (link "Ppx" Ppx/index.html Ppx)))
+    (link "PostgreSQL config" ocsipersist-pgsql-config/Ocsipersist_config/index.html  ocsipersist-pgsql-config)))


### PR DESCRIPTION
Migrates the ocsipersist documentation to the odoc + wodoc pipeline (declarative `doc/wodoc` config + `dune build @doc` CI), on top of the modernize branch (wrapped ocsigenserver module names).

- adds the wodoc config + Documentation workflow (builds `dev` on push)
- adds an Ocsipersist overview landing page (`doc/index.mld`)
- drops the dead Ppx API nav entry

Draft — part of the cross-project Ocsigen doc migration to wodoc.