### PR TITLE
doc: odoc/wodoc migration — manual + API (latest / 2.0)

### DIFF
--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,2 @@
+(documentation
+ (package ocsipersist))

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,42 @@
+{0 Ocsipersist}
+
+Ocsipersist is a collection of libraries defining a unified frontend for a
+number of key/value storage implementations. It is used pervasively in
+Ocsigen/Eliom to handle sessions and persistent references, but can be used as
+a standalone library or as an extension for Ocsigen Server.
+
+Three backends currently exist:
+
+- {{:../ocsipersist-sqlite/index.html}SQLite}
+- {{:../ocsipersist-dbm/index.html}DBM}
+- {{:../ocsipersist-pgsql/index.html}PostgreSQL}
+
+You choose a backend by installing the corresponding package
+([ocsipersist-sqlite], [ocsipersist-dbm] or [ocsipersist-pgsql]); the unified
+frontend is the same in every case.
+
+{1 API reference}
+
+The storage frontend is documented in module {!Ocsipersist}. It defines several
+interfaces:
+
+- [Ref] — the simplest to use: persistent references;
+- [Store] — a lower-level interface for persistent values;
+- [Polymorphic] — a polymorphic table (using [Marshal]);
+- [Functorial] — a type-safe table built from a value description.
+
+See {!Ocsipersist} for the full frontend, and {!Ocsipersist_lib} for the
+backend-independent signatures and functors shared by every backend.
+
+{1 Backends and configuration}
+
+Each backend ships an [Ocsipersist_settings] library to configure storage from
+OCaml, and an optional [ocsipersist-*-config] package to configure it from
+Ocsigen Server's configuration file:
+
+- SQLite: {{:../ocsipersist-sqlite/index.html}usage} ·
+  {{:../ocsipersist-sqlite-config/Ocsipersist_config/index.html}server config}
+- DBM: {{:../ocsipersist-dbm/index.html}usage} ·
+  {{:../ocsipersist-dbm-config/Ocsipersist_config/index.html}server config}
+- PostgreSQL: {{:../ocsipersist-pgsql/index.html}usage} ·
+  {{:../ocsipersist-pgsql-config/Ocsipersist_config/index.html}server config}


### PR DESCRIPTION
Stable-version (2.0) documentation sources for the odoc + wodoc pipeline. Adds the Ocsipersist overview landing page (`doc/index.mld`).

Draft — part of the cross-project Ocsigen doc migration to wodoc; companion to the dev branch wodoc-doc.