### PR TITLE
ci: cancel superseded CI runs (add concurrency group)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-and-test:
     name: ${{ matrix.os }} / OCaml ${{ matrix.ocaml-compiler }}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -12,6 +12,10 @@ on:
         description: "Publish a stable version: freeze the dev docs now on gh-pages as /<version>/ and repoint `latest` (e.g. 1.2.3). Leave empty to just rebuild dev."
         required: false
         default: ""
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-deploy:
     if: github.repository == 'ocsigen/ocsipersist' && (github.event_name != 'workflow_dispatch' || github.event.inputs.version == '')


### PR DESCRIPTION
The org's CI shares a single pool of GitHub-hosted runners (free plan, ~20
concurrent jobs across **all** repos). With many open PRs and large build
matrices, runs were piling up: every new push stacked another full run on top
of the previous one, which kept **queued** instead of being cancelled. Plain
`ubuntu-latest` jobs ended up waiting for hours, starving every other repo.

This adds a `concurrency` group so a new push to a PR cancels the superseded,
still-running run for that same ref. Cancellation is scoped to
`pull_request` events only, so pushes/deploys on the default branch are never
cancelled.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```