### PR TITLE
ocsipersist-dbm: mark as Unix-only

### DIFF
--- a/ocsipersist-dbm.opam
+++ b/ocsipersist-dbm.opam
@@ -32,4 +32,4 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
 x-maintenance-intent: ["(latest)"]
-available: os != "win32"
+available: os != "macos" & os != "win32"

--- a/ocsipersist-dbm.opam
+++ b/ocsipersist-dbm.opam
@@ -32,4 +32,4 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
 x-maintenance-intent: ["(latest)"]
-available: [os != "macos"]
+available: os != "win32"

--- a/ocsipersist-dbm.opam.template
+++ b/ocsipersist-dbm.opam.template
@@ -1,1 +1,1 @@
-available: [os != "macos"]
+available: os != "win32"

--- a/ocsipersist-dbm.opam.template
+++ b/ocsipersist-dbm.opam.template
@@ -1,1 +1,1 @@
-available: os != "win32"
+available: os != "macos" & os != "win32"


### PR DESCRIPTION
The DBM backend is Unix-only by design (Unix-domain sockets + a separate `ocsidbm` process, and `gdbm`/`ndbm` which are unavailable on Windows). Declare `available: os != "win32"` via an `ocsipersist-dbm.opam.template` so the generated opam file carries the constraint.

Packages that are Unix-only only *through a dependency* (the `*-config` packages, via `ocsigenserver`) are deliberately **not** marked, since such dependencies may gain Windows support later.

Context: surfaced by the opam-repository CI for the 2.1.0 release (ocaml/opam-repository#30046).