### PR TITLE
doc: update doc/wodoc for wodoc's new defaults

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -4,7 +4,8 @@
 ;;               --label <v> --menu <shared menu.html> [--latest]
 (project ocsipersist)
 (title Ocsipersist)
-(pub /ocsipersist)
+(url-prefix /ocsipersist)
+(css /css/style.css /css/ocsigen-odoc.css)  ; shared Ocsigen theme (wodoc css default changed)
 (profile release)                       ; dune build @doc --profile release
 (landing ocsipersist/index.html)
 ;; no (highlight …): Ocsipersist has no ppx, so wodoc's default starter is enough.


### PR DESCRIPTION
wodoc master now ships a built-in default theme and renames the `pub` stanza to `url-prefix` (see ocsigen/wodoc). This keeps Ocsipersist's doc on the shared Ocsigen theme and adopts the new name:

- add `(css /css/style.css /css/ocsigen-odoc.css)` (wodoc's css default changed to a self-contained built-in theme, so this is now needed to keep the shared `/css/` look);
- rename `(pub …)` → `(url-prefix …)`.

The doc CI tracks wodoc master, so no CI change is needed.