### PR TITLE
Adapt to Ocsigen Server 8: wrapped ocsigenserver module names

### DIFF
--- a/src/dbm/ocsipersist_config.ml
+++ b/src/dbm/ocsipersist_config.ml
@@ -8,14 +8,14 @@ let rec parse_global_config ((store, ocsidbm, delayloading) as d) = function
   | Xml.Element ("store", [("dir", s)], []) :: ll ->
       if store = None
       then parse_global_config (Some s, ocsidbm, delayloading) ll
-      else Ocsigen_extensions.badconfig "Ocsipersist: Duplicate <store> tag"
+      else Ocsigen.Extensions.badconfig "Ocsipersist: Duplicate <store> tag"
   | Xml.Element ("ocsidbm", [("name", s)], []) :: ll ->
       if ocsidbm = None
       then parse_global_config (store, Some s, delayloading) ll
-      else Ocsigen_extensions.badconfig "Ocsipersist: Duplicate <ocsidbm> tag"
-  | Xml.Element (s, _, _) :: _ll -> Ocsigen_extensions.badconfig "Bad tag %s" s
+      else Ocsigen.Extensions.badconfig "Ocsipersist: Duplicate <ocsidbm> tag"
+  | Xml.Element (s, _, _) :: _ll -> Ocsigen.Extensions.badconfig "Bad tag %s" s
   | _ ->
-      Ocsigen_extensions.badconfig
+      Ocsigen.Extensions.badconfig
         "Unexpected content inside Ocsipersist config"
 
 let init_fun config =
@@ -23,15 +23,15 @@ let init_fun config =
     parse_global_config (None, None, false) config
   in
   Ocsipersist_settings.delay_loading := delay_loading;
-  Ocsipersist_settings.error_log_path := Ocsigen_messages.error_log_path ();
+  Ocsipersist_settings.error_log_path := Ocsigen.Messages.error_log_path ();
   (match store with
   | None ->
       Ocsipersist_settings.directory :=
-        Ocsigen_config.get_datadir () ^ "/ocsipersist"
+        Ocsigen.Config.get_datadir () ^ "/ocsipersist"
   | Some d -> Ocsipersist_settings.directory := d);
   (match ocsidbmconf with
   | None -> ()
   | Some d -> Ocsipersist_settings.ocsidbm := d);
   Ocsipersist.init ()
 
-let () = Ocsigen_extensions.register ~name:"ocsipersist" ~init_fun ()
+let () = Ocsigen.Extensions.register ~name:"ocsipersist" ~init_fun ()

--- a/src/pgsql/ocsipersist_config.ml
+++ b/src/pgsql/ocsipersist_config.ml
@@ -12,7 +12,7 @@ let parse_global_config = function
           try Ocsipersist_settings.port := Some (int_of_string p)
           with Failure _ ->
             raise
-            @@ Ocsigen_extensions.Error_in_config_file "port is not an integer")
+            @@ Ocsigen.Extensions.Error_in_config_file "port is not an integer")
         | "user", u -> Ocsipersist_settings.user := Some u
         | "password", pw -> Ocsipersist_settings.password := Some pw
         | "database", db -> Ocsipersist_settings.database := db
@@ -22,19 +22,19 @@ let parse_global_config = function
           try Ocsipersist_settings.size_conn_pool := int_of_string scp
           with Failure _ ->
             raise
-            @@ Ocsigen_extensions.Error_in_config_file
+            @@ Ocsigen.Extensions.Error_in_config_file
                  "size_conn_pool is not an integer")
         | _ ->
             raise
-            @@ Ocsigen_extensions.Error_in_config_file
+            @@ Ocsigen.Extensions.Error_in_config_file
                  "Unexpected attribute for <database> in Ocsipersist config"
       in
       ignore @@ List.map parse_attr attrs;
       ()
   | _ ->
       raise
-      @@ Ocsigen_extensions.Error_in_config_file
+      @@ Ocsigen.Extensions.Error_in_config_file
            "Unexpected content inside Ocsipersist config"
 
 let init_fun config = parse_global_config config; Ocsipersist.init ()
-let () = Ocsigen_extensions.register ~name:"ocsipersist" ~init_fun ()
+let () = Ocsigen.Extensions.register ~name:"ocsipersist" ~init_fun ()

--- a/src/sqlite/ocsipersist_config.ml
+++ b/src/sqlite/ocsipersist_config.ml
@@ -3,20 +3,20 @@ let parse_global_config = function
   | [Xml.Element ("database", [("file", s)], [])] -> Some s
   | _ ->
       raise
-        (Ocsigen_extensions.Error_in_config_file
+        (Ocsigen.Extensions.Error_in_config_file
            "Unexpected content inside Ocsipersist config")
 
 let init config =
-  Ocsipersist_settings.db_file := Ocsigen_config.get_datadir () ^ "/ocsidb";
+  Ocsipersist_settings.db_file := Ocsigen.Config.get_datadir () ^ "/ocsidb";
   (match parse_global_config config with
   | None -> ()
   | Some d -> Ocsipersist_settings.db_file := d);
   try Ocsipersist.init ()
   with e ->
-    Ocsigen_messages.errlog
+    Ocsigen.Messages.errlog
       (Printf.sprintf
          "Error opening database file '%s' when registering Ocsipersist. Check that the directory exists, and that Ocsigen has enough rights"
          !Ocsipersist_settings.db_file);
     raise e
 
-let () = Ocsigen_extensions.register ~name:"ocsipersist" ~init_fun:init ()
+let () = Ocsigen.Extensions.register ~name:"ocsipersist" ~init_fun:init ()


### PR DESCRIPTION
Makes ocsipersist build against Ocsigen Server 8.

Server 8 dropped the flat module names (`Ocsigen_extensions`, `Ocsigen_config`, `Ocsigen_messages`) in favour of the wrapped `Ocsigen.Extensions` / `Ocsigen.Config` / `Ocsigen.Messages`. The released 2.1.0 still uses the flat names, so it does not compile against Server 8.

This migrates the 3 config files. (The same change existed only on the stale `modernize` branch; ported here on top of `master`.)

After merge, `master` is Server-8 ready. `deriving` is a strict subset of `master` (0 commits ahead) and can be deleted.