### PR TITLE
CI: pin ocsigenserver#master for Server 8

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
+      # Ocsipersist targets the Ocsigen Server 8 API (wrapped module names),
+      # which is only available from the master pin until 8.0 is released.
+      - run: opam pin -yn git+https://github.com/ocsigen/ocsigenserver#master
+
       - name: Install dependencies
         run: opam install . --deps-only --with-test
 


### PR DESCRIPTION
ocsipersist now uses the wrapped `Ocsigen.Extensions`/`Ocsigen.Config`/`Ocsigen.Messages` modules (Server 8). Pin `ocsigenserver#master` so CI builds against Server 8 instead of the released 7.x.