### PR TITLE
ci(doc): cache the opam switch to skip recompiling the dependency tree

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -31,7 +31,26 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: "5.4.0"
+      # The bottleneck of this job is compiling the dependency tree plus wodoc and
+      # odoc from source; setup-ocaml only caches the base switch (the compiler),
+      # so they recompiled on every push. Cache the whole _opam switch keyed on the
+      # *.opam files (the dep set) and wodoc's HEAD commit; on a cache hit the
+      # install is skipped and only the project itself is (re)built by the doc step
+      # below. The key changes -- and the deps/wodoc rebuild once -- only when an
+      # *.opam file or wodoc move.
+      - name: Resolve wodoc HEAD commit
+        id: wodoc
+        run: echo "sha=$(git ls-remote https://github.com/ocsigen/wodoc.git HEAD | cut -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache the opam switch (deps + wodoc)
+        id: switch-cache
+        uses: actions/cache@v4
+        with:
+          path: _opam
+          key: opam-switch-${{ runner.os }}-ocaml5.4.0-${{ hashFiles('*.opam') }}-wodoc-${{ steps.wodoc.outputs.sha }}
+
       - name: Install dependencies
+        if: steps.switch-cache.outputs.cache-hit != 'true'
         run: |
           opam install . --deps-only --with-doc
           opam pin add -n wodoc https://github.com/ocsigen/wodoc.git


### PR DESCRIPTION
## Problem

The `Documentation` workflow recompiles the dependency tree plus wodoc and odoc from source on **every push** (several minutes); `setup-ocaml@v3` only caches the base switch (the compiler), so none of that was cached.

## Fix

Cache the whole `_opam` switch with `actions/cache`, keyed on the `*.opam` files (the dependency set) and wodoc's resolved HEAD commit. On a cache hit the install step is skipped; the project itself is still rebuilt from the checkout by `dune build @doc` in the doc step, so the docs stay current. The cache rebuilds once when an `*.opam` file or wodoc's HEAD move.

Same change validated on **ocsigen.github.io** (4 min → ~1 min) and **ocsigenserver** (5 min → ~1 min, cache hit confirmed). First run on this branch is a cache miss (populates the cache); the speed-up shows on the next run.

> The `release` job (manual, infrequent) is left as-is.